### PR TITLE
It's a small program. Everything goes in this commit

### DIFF
--- a/go/cmd/ccmysql/main.go
+++ b/go/cmd/ccmysql/main.go
@@ -2,17 +2,13 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"github.com/github/ccmysql/go/logic"
-	"github.com/outbrain/golib/log"
-	"github.com/outbrain/golib/sqlutils"
-	"os/user"
-	"strings"
-)
 
-const (
-	maxConcurrentConnections = 128
-	defaultMySQLPort         = 3306
+	"github.com/github/ccmysql/go/logic"
+	"github.com/github/ccmysql/go/sql"
+	"github.com/github/ccmysql/go/text"
+
+	"github.com/outbrain/golib/log"
+	"os/user"
 )
 
 // main is the application's entry point. It will either spawn a CLI or HTTP itnerfaces.
@@ -25,31 +21,37 @@ func main() {
 
 	user := flag.String("u", osUser, "MySQL username")
 	password := flag.String("p", "", "MySQL password")
-	//hostsFile := flag.String("H", "", "Hosts file (read from stdin if not given); expected hostname[:port] per line")
-	query := flag.String("q", "", "Query/queries to execute")
+	hostsList := flag.String("h", "", "Comma or space delimited list of hosts in hostname[:port] format. If not given, hosts read from stdin")
+	hostsFile := flag.String("H", "", "Hosts file, hostname[:port] comma or space or newline delimited format. If not given, hosts read from stdin")
+	queriesText := flag.String("q", "", "Query/queries to execute")
+	queriesFile := flag.String("Q", "", "Query/queries input file")
 	timeout := flag.Int("t", 0, "Connect timeout seconds")
 	flag.Parse()
 
-	if *query == "" {
-		log.Fatalf("You must provide a query via -q")
+	if *queriesText == "" && *queriesFile == "" {
+		log.Fatalf(`You must provide a query via -q "<some query>" or via -Q <query-file>`)
+	}
+	if *hostsList != "" && *hostsFile != "" {
+		log.Fatalf("Both -q and -Q given. Please specify exactly one")
+	}
+	queries, err := sql.ParseQueries(*queriesText, *queriesFile)
+	if err != nil {
+		log.Fatale(err)
+	}
+	if len(queries) == 0 {
+		log.Fatalf("No query/queries given")
 	}
 
-	concurrentHosts := make(chan bool, maxConcurrentConnections)
-	completedHosts := make(chan bool)
-
-	var hosts []string = []string{"shlomi-gh:22295", "shlomi-gh:22296", "", "shlomi-gh"}
-
-	for _, host := range hosts {
-		go func(host string) {
-			concurrentHosts <- true
-			queryHost(host, *user, *password, *query, *timeout)
-			<-concurrentHosts
-
-			completedHosts <- true
-		}(host)
+	if *hostsList != "" && *hostsFile != "" {
+		log.Fatalf("Both -h and -H given. Please choose either one, or none (in which case stdin is used)")
 	}
-	// Barrier. Wait for all to complete
-	for range hosts {
-		<-completedHosts
+	hosts, err := text.ParseHosts(*hostsList, *hostsFile)
+	if err != nil {
+		log.Fatale(err)
 	}
+	if len(hosts) == 0 {
+		log.Fatalf("No hosts given")
+	}
+
+	logic.QueryHosts(hosts, *user, *password, queries, *timeout)
 }

--- a/go/sql/query.go
+++ b/go/sql/query.go
@@ -1,0 +1,34 @@
+package sql
+
+import (
+	"io/ioutil"
+	"regexp"
+	"strings"
+)
+
+// ParseQueries parses multiple queries given a single string.
+// Input may be a semicolon delimited set of queries, such as:
+// `select 1; show variables; select '2;nd'`
+// Empty queries are ignored and skipped. Result is an array of single queries.
+func ParseQueries(queriesText string, queriesFile string) (queries []string, err error) {
+	if queriesFile != "" {
+		bytes, err := ioutil.ReadFile(queriesFile)
+		if err != nil {
+			return queries, err
+		}
+		queriesText = string(bytes)
+	}
+
+	// The following regexp makes for a reasonable (yet incomplete) parses that splits
+	// by delimiter ";" yet ignores it when it is quoted
+	r := regexp.MustCompile(`([^;']+|'([^']*)')+[;]?`)
+	matches := r.FindAllString(queriesText, -1)
+	for _, match := range matches {
+		match = strings.TrimSuffix(match, ";")
+		match = strings.TrimSpace(match)
+		if match != "" {
+			queries = append(queries, match)
+		}
+	}
+	return queries, nil
+}

--- a/go/sql/query_test.go
+++ b/go/sql/query_test.go
@@ -1,0 +1,84 @@
+package sql
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseQueriesSingle(t *testing.T) {
+	queriesText := `select 1`
+	queries, err := ParseQueries(queriesText, "")
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if len(queries) != 1 {
+		t.Errorf("expected 1 query; got %+v", len(queries))
+	}
+	if queries[0] != `select 1` {
+		t.Errorf("got unexpected query `%+v`", queries[0])
+	}
+}
+
+func TestParseQueriesMulti(t *testing.T) {
+	useCases := []string{
+		`select 1; select 2; select 3`,
+		`select 1; select 2; select 3 `,
+		` select 1; select 2 ; select 3;`,
+		`select 1; select 2; select 3; `,
+		`select 1; ;;select 2; select 3;`,
+		`select 1;
+                    select 2; select 3;`,
+	}
+	expected := `select 1;select 2;select 3`
+	for _, queriesText := range useCases {
+		queries, err := ParseQueries(queriesText, "")
+
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if len(queries) != 3 {
+			t.Errorf("expected 3 queries; got %+v", len(queries))
+		}
+		result := strings.Join(queries, ";")
+		if result != expected {
+			t.Errorf("got unexpected results: `%+v`", result)
+		}
+	}
+}
+
+func TestParseQueriesEmpty(t *testing.T) {
+	useCases := []string{
+		``,
+		`  `,
+		`;`,
+		`  ;;; ; ; `,
+	}
+	for _, queriesText := range useCases {
+		queries, err := ParseQueries(queriesText, "")
+
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if len(queries) != 0 {
+			t.Errorf("expected 0 queries; got %+v", len(queries))
+		}
+	}
+}
+
+func TestParseQueriesQuotes(t *testing.T) {
+	queriesText := `select 1; select '2;2' ; select 3`
+	queries, err := ParseQueries(queriesText, "")
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if len(queries) != 3 {
+		t.Errorf("expected 3 queries; got %+v", len(queries))
+		t.Errorf("%+v", strings.Join(queries, "::"))
+	}
+	result := strings.Join(queries, ";")
+	if result != `select 1;select '2;2';select 3` {
+		t.Errorf("got unexpected results: `%+v`", result)
+	}
+}

--- a/go/text/hosts.go
+++ b/go/text/hosts.go
@@ -1,0 +1,45 @@
+package text
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+)
+
+const (
+	defaultMySQLPort = 3306
+)
+
+// ParseHosts will return list of hostnames from either given list,
+// or file, or stdin.
+func ParseHosts(hostsList string, hostsFile string) (hosts []string, err error) {
+	if hostsFile != "" {
+		bytes, err := ioutil.ReadFile(hostsFile)
+		if err != nil {
+			return hosts, err
+		}
+		hostsList = string(bytes)
+	}
+	if hostsList == "" {
+		// Read from stdin
+		bytes, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return hosts, err
+		}
+		hostsList = string(bytes)
+	}
+	parsedHosts := regexp.MustCompile("[,\\s]").Split(hostsList, -1)
+	for _, host := range parsedHosts {
+		host = strings.TrimSpace(host)
+		if host != "" {
+			if !strings.Contains(host, ":") {
+				host = fmt.Sprintf("%s:%d", host, defaultMySQLPort)
+			}
+			hosts = append(hosts, host)
+		}
+	}
+
+	return hosts, err
+}

--- a/go/text/hosts_test.go
+++ b/go/text/hosts_test.go
@@ -1,0 +1,50 @@
+package text
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseHostsSingle(t *testing.T) {
+	hostsList := `localhost`
+	hosts, err := ParseHosts(hostsList, "")
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if len(hosts) != 1 {
+		t.Errorf("expected 1 host; got %+v", len(hosts))
+	}
+	if hosts[0] != `localhost:3306` {
+		t.Errorf("got unexpected host `%+v`", hosts[0])
+	}
+}
+
+func TestParseHostsMulti(t *testing.T) {
+	useCases := []string{
+		`host1 host2:4408 host3`,
+		` host1 host2:4408 host3 `,
+		`host1, host2:4408, host3,`,
+		`host1
+            host2:4408
+            host3`,
+		`host1  ,
+            host2:4408 host3`,
+		`host1, ,, host2:4408, host3, ,,`,
+	}
+	expected := `host1:3306,host2:4408,host3:3306`
+	for _, hostsList := range useCases {
+		hosts, err := ParseHosts(hostsList, "")
+
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if len(hosts) != 3 {
+			t.Errorf("expected 3 hosts; got %+v", len(hosts))
+		}
+		result := strings.Join(hosts, ",")
+		if result != expected {
+			t.Errorf("got unexpected results: `%+v`", result)
+		}
+	}
+}


### PR DESCRIPTION
All righty. What is this?
Remember [Domas](http://dom.as/2010/08/12/pmysql-multi-server-mysql-client/)'s _pmysql_?

I happened to use it a lot; I know others have; it's not in bazaar anymore, and when it still was, it was a nightmare to build per OS.

We would need pmysql-equivalent, for example, to apply changes massively across our topologies. Say I want to change `slave_net_timeout := 20` on all our servers. How? Or `select server_id` to confirm change of configuration. How?

Enter `ccmysql`, which does just that, in parallel. You may issue a DML or DDL or multiple queries, on multiple hosts. You will need to provide your own username & password.

And how will `ccmysql` get the relevant hosts list in the first place? That's a job for `orchestrator` and this is a different discussion
