### PR TITLE
support for '-d database' parameter

### DIFF
--- a/go/cmd/ccql/main.go
+++ b/go/cmd/ccql/main.go
@@ -27,6 +27,7 @@ func main() {
 	user := flag.String("u", osUser, "MySQL username")
 	password := flag.String("p", "", "MySQL password")
 	credentialsFile := flag.String("C", "", "Credentials file, expecting [client] scope, with 'user', 'password' fields. Overrides -u and -p")
+	defaultSchema := flag.String("d", "information_schema", "Default schema to use")
 	hostsList := flag.String("h", "", "Comma or space delimited list of hosts in hostname[:port] format. If not given, hosts read from stdin")
 	hostsFile := flag.String("H", "", "Hosts file, hostname[:port] comma or space or newline delimited format. If not given, hosts read from stdin")
 	queriesText := flag.String("q", "", "Query/queries to execute")
@@ -83,5 +84,5 @@ func main() {
 		}
 	}
 
-	logic.QueryHosts(hosts, *user, *password, queries, *maxConcurrency, *timeout)
+	logic.QueryHosts(hosts, *user, *password, *defaultSchema, queries, *maxConcurrency, *timeout)
 }

--- a/go/logic/ccql.go
+++ b/go/logic/ccql.go
@@ -10,8 +10,8 @@ import (
 
 // queryHost connects to a given host, issues the given set of queries, and outputs the results
 // line per row in tab delimited format
-func queryHost(host string, user string, password string, queries []string, timeout uint) error {
-	mysqlURI := fmt.Sprintf("%s:%s@tcp(%s)/?timeout=%ds", user, password, host, timeout)
+func queryHost(host string, user string, password string, defaultSchema string, queries []string, timeout uint) error {
+	mysqlURI := fmt.Sprintf("%s:%s@tcp(%s)/%s?timeout=%ds", user, password, host, defaultSchema, timeout)
 	db, _, err := sqlutils.GetDB(mysqlURI)
 	if err != nil {
 		return log.Errore(err)
@@ -35,14 +35,14 @@ func queryHost(host string, user string, password string, queries []string, time
 }
 
 // QueryHosts will issue concurrent queries on given list of hosts
-func QueryHosts(hosts []string, user string, password string, queries []string, maxConcurrency uint, timeout uint) {
+func QueryHosts(hosts []string, user string, password string, defaultSchema string, queries []string, maxConcurrency uint, timeout uint) {
 	concurrentHosts := make(chan bool, maxConcurrency)
 	completedHosts := make(chan bool)
 
 	for _, host := range hosts {
 		go func(host string) {
 			concurrentHosts <- true
-			queryHost(host, user, password, queries, timeout)
+			queryHost(host, user, password, defaultSchema, queries, timeout)
 			<-concurrentHosts
 
 			completedHosts <- true


### PR DESCRIPTION
Default schema is now `information_schema` (always exists and is read-only). Pass `-d other_schema` to change default schema. Empty string is accepted.
