### PR TITLE
print defaults when no query given

### DIFF
--- a/go/cmd/ccql/main.go
+++ b/go/cmd/ccql/main.go
@@ -30,6 +30,7 @@ func main() {
 		osUser = usr.Username
 	}
 
+	help := flag.Bool("help", false, "Display usage")
 	user := flag.String("u", osUser, "MySQL username")
 	password := flag.String("p", "", "MySQL password")
 	credentialsFile := flag.String("C", "", "Credentials file, expecting [client] scope, with 'user', 'password' fields. Overrides -u and -p")
@@ -42,9 +43,14 @@ func main() {
 	maxConcurrency := flag.Uint("m", 32, "Max concurrent connections")
 	flag.Parse()
 
+	if *help {
+		fmt.Fprintf(os.Stderr, "Usage of ccql:\n")
+		flag.PrintDefaults()
+		return
+	}
 	if *queriesText == "" && *queriesFile == "" {
-		fmt.Fprintf(os.Stderr, `You must provide a query via -q "<some query>" or via -Q <query-file>`)
-		fmt.Fprintln(os.Stderr)
+		fmt.Fprintf(os.Stderr, "You must provide a query via -q '<some query>' or via -Q <query-file>\n")
+		fmt.Fprintf(os.Stderr, "Usage of ccql:\n")
 		flag.PrintDefaults()
 		return
 	}


### PR DESCRIPTION
closes https://github.com/github/ccql/issues/15 :

``` bash
$ ccql
You must provide a query via -q "<some query>" or via -Q <query-file>
  -C string
        Credentials file, expecting [client] scope, with 'user', 'password' fields. Overrides -u and -p
  -H string
        Hosts file, hostname[:port] comma or space or newline delimited format. If not given, hosts read from stdin
  -Q string
        Query/queries input file
  -d string
        Default schema to use (default "information_schema")
  -h string
        Comma or space delimited list of hosts in hostname[:port] format. If not given, hosts read from stdin
  -m uint
        Max concurrent connections (default 32)
  -p string
        MySQL password
  -q string
        Query/queries to execute
  -t uint
        Connect timeout seconds
  -u string
        MySQL username (default "buck-rogers")
```
