### PR TITLE
timeout is float64

### DIFF
--- a/go/cmd/ccql/main.go
+++ b/go/cmd/ccql/main.go
@@ -39,7 +39,7 @@ func main() {
 	hostsFile := flag.String("H", "", "Hosts file, hostname[:port] comma or space or newline delimited format. If not given, hosts read from stdin")
 	queriesText := flag.String("q", "", "Query/queries to execute")
 	queriesFile := flag.String("Q", "", "Query/queries input file")
-	timeout := flag.Uint("t", 0, "Connect timeout seconds")
+	timeout := flag.Float64("t", 0, "Connect timeout seconds")
 	maxConcurrency := flag.Uint("m", 32, "Max concurrent connections")
 	flag.Parse()
 

--- a/go/logic/ccql.go
+++ b/go/logic/ccql.go
@@ -10,8 +10,9 @@ import (
 
 // queryHost connects to a given host, issues the given set of queries, and outputs the results
 // line per row in tab delimited format
-func queryHost(host string, user string, password string, defaultSchema string, queries []string, timeout uint) error {
-	mysqlURI := fmt.Sprintf("%s:%s@tcp(%s)/%s?timeout=%ds", user, password, host, defaultSchema, timeout)
+func queryHost(host string, user string, password string, defaultSchema string, queries []string, timeout float64) error {
+	mysqlURI := fmt.Sprintf("%s:%s@tcp(%s)/%s?timeout=%fs", user, password, host, defaultSchema, timeout)
+	fmt.Println(mysqlURI)
 	db, _, err := sqlutils.GetDB(mysqlURI)
 	if err != nil {
 		return err
@@ -35,7 +36,7 @@ func queryHost(host string, user string, password string, defaultSchema string, 
 }
 
 // QueryHosts will issue concurrent queries on given list of hosts
-func QueryHosts(hosts []string, user string, password string, defaultSchema string, queries []string, maxConcurrency uint, timeout uint) {
+func QueryHosts(hosts []string, user string, password string, defaultSchema string, queries []string, maxConcurrency uint, timeout float64) {
 	concurrentHosts := make(chan bool, maxConcurrency)
 	completedHosts := make(chan bool)
 


### PR DESCRIPTION
timeout can now be expressed as float, e.g. `-t 0.2`, which allows for subsecond timeouts.

See https://github.com/github/ccql/issues/24
