### PR TITLE
ccql is relaxed in parsing config file

### DIFF
--- a/go/cmd/ccql/main.go
+++ b/go/cmd/ccql/main.go
@@ -90,6 +90,7 @@ func main() {
 				Password string
 			}
 		}{}
+		gcfg.RelaxedParserMode = true
 		err := gcfg.ReadFileInto(&mySQLConfig, *credentialsFile)
 		if err != nil {
 			log.Fatalf("Failed to parse gcfg data from file: %+v", err)

--- a/vendor/gopkg.in/gcfg.v1/set.go
+++ b/vendor/gopkg.in/gcfg.v1/set.go
@@ -16,6 +16,8 @@ type tag struct {
 	intMode string
 }
 
+var RelaxedParserMode = false
+
 func newTag(ts string) tag {
 	t := tag{}
 	s := strings.Split(ts, ",")
@@ -197,6 +199,9 @@ func set(cfg interface{}, sect, sub, name string, blank bool, value string) erro
 	vCfg := vPCfg.Elem()
 	vSect, _ := fieldFold(vCfg, sect)
 	if !vSect.IsValid() {
+		if RelaxedParserMode {
+			return nil
+		}
 		return fmt.Errorf("invalid section: section %q", sect)
 	}
 	if vSect.Kind() == reflect.Map {
@@ -232,6 +237,9 @@ func set(cfg interface{}, sect, sub, name string, blank bool, value string) erro
 	}
 	vVar, t := fieldFold(vSect, name)
 	if !vVar.IsValid() {
+		if RelaxedParserMode {
+			return nil
+		}
 		return fmt.Errorf("invalid variable: "+
 			"section %q subsection %q variable %q", sect, sub, name)
 	}


### PR DESCRIPTION
Storyline: https://github.com/github/ccql/issues/31

`ccql` is now relaxed in parsing the credentials config file. It will happily read a file such as:

```
[client]
user=msandbox
password=msandbox
unknown=anything

[unfamiliar]
never_seen_before=anyvalue
```

... that has `[client]` variables unknown to `ccql`, and unknown sections such as `[unfamiliar]`. This allows `ccql` to read a common `my.ini` mysql configuration file and silently ignore MySQL variables that are unrelated to `ccql`

cc @datacharmer 