### PR TITLE
Supporting multiple Go versions

### DIFF
--- a/script/ensure-go-installed
+++ b/script/ensure-go-installed
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 GO_VERSION=go1.7
+ALLOWED_VERSIONS="(go1.7|go1.8|go1.9)"
 
 GO_PKG_DARWIN=${GO_VERSION}.darwin-amd64.pkg
 GO_PKG_DARWIN_SHA=e7089843bc7148ffcc147759985b213604d22bb9fd19bd930b515aa981bf1b22
@@ -12,7 +13,7 @@ export ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 cd $ROOTDIR
 
 # If Go isn't installed globally, setup environment variables for local install.
-if [ -z "$(which go)" ] || [ -z "$(go version | grep $GO_VERSION)" ]; then
+if [ -z "$(which go)" ] || [ -z "$(go version | egrep "$ALLOWED_VERSIONS")" ]; then
   GODIR="$ROOTDIR/.vendor/go17"
 
   if [ $(uname -s) = "Darwin" ]; then
@@ -25,7 +26,7 @@ if [ -z "$(which go)" ] || [ -z "$(go version | grep $GO_VERSION)" ]; then
 fi
 
 # Check if local install exists, and install otherwise.
-if [ -z "$(which go)" ] || [ -z "$(go version | grep $GO_VERSION)" ]; then
+if [ -z "$(which go)" ] || [ -z "$(go version | egrep "$ALLOWED_VERSIONS")" ]; then
   [ -d "$GODIR" ] && rm -rf $GODIR
   mkdir -p "$GODIR"
   cd "$GODIR";
@@ -42,7 +43,7 @@ if [ -z "$(which go)" ] || [ -z "$(go version | grep $GO_VERSION)" ]; then
   fi
 
   # Prove we did something right
-  echo "$GO_VERSION installed in $GODIR: Go Binary: $(which go)"
+  echo "go installed in $GODIR: Go Binary: $(which go), version: $(go version)"
 fi
 
 cd $ROOTDIR


### PR DESCRIPTION
With this PR CI trusts a local `go1.[789]*` version, if exists.